### PR TITLE
Choose runtime

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,6 +11,7 @@
         "datnames",
         "dbname",
         "dealias",
+        "Deque",
         "doctest",
         "dtolnay",
         "EAGAIN",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
     "cSpell.words": [
         "aarch",
         "bindir",
+        "bitand",
         "canonicalize",
         "clippy",
         "createdb",
@@ -17,6 +18,7 @@
         "EAGAIN",
         "errno",
         "fcntl",
+        "globset",
         "initdb",
         "lockpath",
         "logfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,6 +134,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c79ad7fb2dd38f3dabd76b09c6a5a20c038fc0213ef1e9afd30eb777f120f019"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -308,6 +318,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fcfdc7a0362c9f4444381a9e697c79d435fe65b52a37466fc2c1184cee9edc6"
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -399,6 +415,19 @@ name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "globset"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "759c97c1e17c55525b57192c06a267cda0ac5210b222d6b82189a2338fa1c13d"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "fnv",
+ "log",
+ "regex",
+]
 
 [[package]]
 name = "heck"
@@ -572,6 +601,7 @@ version = "0.2.0"
 dependencies = [
  "either",
  "glob",
+ "globset",
  "lazy_static",
  "nix",
  "postgres",
@@ -805,6 +835,26 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "serde"
+version = "1.0.188"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.188"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "sha1_smol"

--- a/pgdo-cli/README.md
+++ b/pgdo-cli/README.md
@@ -1,5 +1,7 @@
 # pgdo-cli
 
+[![pgdo CI](https://github.com/allenap/pgdo/actions/workflows/build.yml/badge.svg)](https://github.com/allenap/pgdo/actions/workflows/build.yml)
+
 A [Rust](https://www.rust-lang.org/) command-line tool for creating standalone
 PostgreSQL clusters and databases with a focus on convenience and rapid
 prototyping – such as one sees using SQLite. Scaling down the developer

--- a/pgdo-cli/src/cli.rs
+++ b/pgdo-cli/src/cli.rs
@@ -35,7 +35,7 @@ pub enum Command {
     /// The runtime shown on the line beginning with `=>` is the default, i.e.
     /// the runtime that will be used when creating a new cluster.
     #[clap(display_order = 3)]
-    Runtimes,
+    Runtimes(RuntimeArgs),
 }
 
 #[derive(Args)]
@@ -111,6 +111,15 @@ pub struct DatabaseArgs {
         display_order = 2
     )]
     pub name: String,
+}
+
+#[derive(Args)]
+pub struct RuntimeArgs {
+    /// Select the default runtime.
+    ///
+    /// This is used when creating new clusters.
+    #[clap(long = "runtime", display_order = 80)]
+    pub runtime: Option<String>,
 }
 
 #[derive(Args)]

--- a/pgdo-cli/src/cli.rs
+++ b/pgdo-cli/src/cli.rs
@@ -3,6 +3,8 @@ use std::path::PathBuf;
 
 use clap::{Args, Parser, Subcommand};
 
+use pgdo::runtime::constraint::Constraint;
+
 /// Work with ephemeral PostgreSQL clusters.
 #[derive(Parser)]
 #[clap(author, version, about = "The convenience of SQLite – but with PostgreSQL", long_about = None)]
@@ -49,6 +51,9 @@ pub struct ShellArgs {
 
     #[clap(flatten)]
     pub lifecycle: LifecycleArgs,
+
+    #[clap(flatten)]
+    pub runtime: RuntimeArgs,
 }
 
 #[derive(Args)]
@@ -62,6 +67,9 @@ pub struct ExecArgs {
 
     #[clap(flatten)]
     pub lifecycle: LifecycleArgs,
+
+    #[clap(flatten)]
+    pub runtime: RuntimeArgs,
 
     /// The executable to invoke. By default it will start a shell.
     #[clap(env = "SHELL", value_name = "COMMAND", display_order = 999)]
@@ -115,11 +123,13 @@ pub struct DatabaseArgs {
 
 #[derive(Args)]
 pub struct RuntimeArgs {
-    /// Select the default runtime.
-    ///
-    /// This is used when creating new clusters.
-    #[clap(long = "runtime", display_order = 80)]
-    pub runtime: Option<String>,
+    /// Select the default runtime, used when creating new clusters.
+    #[clap(
+        long = "runtime-default",
+        value_name = "CONSTRAINT",
+        display_order = 80
+    )]
+    pub fallback: Option<Constraint>,
 }
 
 #[derive(Args)]

--- a/pgdo-cli/src/main.rs
+++ b/pgdo-cli/src/main.rs
@@ -17,6 +17,7 @@ use pgdo::{
         self,
         strategy::{Strategy, StrategyLike},
     },
+    version,
 };
 
 fn main() -> Result<()> {
@@ -56,7 +57,7 @@ fn main() -> Result<()> {
             let strategy = runtime::strategy::Strategy::default();
             let fallback: Option<_> = constraint
                 .and_then(|c| c.parse().ok())
-                .and_then(|version| strategy.select(&version));
+                .and_then(|version: version::PartialVersion| strategy.select(&version.into()));
             let strategy = match fallback {
                 Some(fallback) => strategy.push_front(fallback),
                 None => strategy,

--- a/pgdo-lib/Cargo.toml
+++ b/pgdo-lib/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/lib.rs"
 [dependencies]
 either = "^1.9.0"
 glob = "^0.3.1"
+globset = "^0.4.13"
 lazy_static = "^1.4.0"
 nix = { version = "^0.27.1", features = ["fs"] }
 postgres = "^0.19.7"

--- a/pgdo-lib/README.md
+++ b/pgdo-lib/README.md
@@ -1,5 +1,7 @@
 # pgdo-lib
 
+[![pgdo CI](https://github.com/allenap/pgdo/actions/workflows/build.yml/badge.svg)](https://github.com/allenap/pgdo/actions/workflows/build.yml)
+
 A [Rust](https://www.rust-lang.org/) library for creating standalone PostgreSQL
 clusters and databases with a focus on convenience and rapid prototyping – such
 as one sees using SQLite. Scaling down the developer experience to meet

--- a/pgdo-lib/README.md
+++ b/pgdo-lib/README.md
@@ -37,7 +37,7 @@ versions that are not supported upstream).
 
 ```rust
 use pgdo::prelude::*;
-for runtime in runtime::strategy::default().runtimes() {
+for runtime in runtime::strategy::Strategy::default().runtimes() {
   let data_dir = tempdir::TempDir::new("data")?;
   let cluster = Cluster::new(&data_dir, runtime)?;
   cluster.start()?;
@@ -79,8 +79,8 @@ coverage. Specifically this means:
 - Install multiple versions of PostgreSQL on your machine. Read on for
   platform-specific notes.
 
-- [`runtime::strategy::default()`] may be able to automatically find those
-  installed runtimes – this is the function used by tests.
+- [`runtime::strategy::Strategy::default()`] may be able to automatically find
+  those installed runtimes – this is the function used by tests.
 
 - If pgdo's platform-specific knowledge doesn't cover your platform, have a go
   at adding to it. [`runtime::strategy::RuntimesOnPlatform`] is a good place to

--- a/pgdo-lib/src/cluster.rs
+++ b/pgdo-lib/src/cluster.rs
@@ -58,7 +58,7 @@ impl Cluster {
                 .ok_or_else(|| ClusterError::RuntimeDefaultNotFound),
             Some(version) => self
                 .strategy
-                .select(&version)
+                .select(&version.into())
                 .ok_or_else(|| ClusterError::RuntimeNotFound(version)),
         }
     }

--- a/pgdo-lib/src/cluster/tests.rs
+++ b/pgdo-lib/src/cluster/tests.rs
@@ -1,5 +1,8 @@
 use super::{exists, version, Cluster, ClusterError, State::*};
-use crate::runtime::{self, strategy::Strategy, Runtime};
+use crate::runtime::{
+    strategy::{Strategy, StrategyLike},
+    Runtime,
+};
 use crate::version::{PartialVersion, Version};
 
 use std::collections::HashSet;
@@ -10,7 +13,7 @@ use std::str::FromStr;
 type TestResult = Result<(), ClusterError>;
 
 fn runtimes() -> Box<dyn Iterator<Item = Runtime>> {
-    let runtimes = runtime::strategy::default().runtimes().collect::<Vec<_>>();
+    let runtimes = Strategy::default().runtimes().collect::<Vec<_>>();
     Box::new(runtimes.into_iter())
 }
 

--- a/pgdo-lib/src/coordinate.rs
+++ b/pgdo-lib/src/coordinate.rs
@@ -8,8 +8,8 @@
 //! use pgdo::prelude::*;
 //! let cluster_dir = tempdir::TempDir::new("cluster")?;
 //! let data_dir = cluster_dir.path().join("data");
-//! let runtime = runtime::strategy::default();
-//! let cluster = Cluster::new(&data_dir, runtime)?;
+//! let strategy = runtime::strategy::Strategy::default();
+//! let cluster = Cluster::new(&data_dir, strategy)?;
 //! let lock_file = cluster_dir.path().join("lock");
 //! let lock = lock::UnlockedFile::try_from(lock_file.as_path())?;
 //! assert!(coordinate::run_and_stop(&cluster, lock, cluster::exists)?);
@@ -142,18 +142,14 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::{
-        cluster::{Cluster, ClusterError},
-        lock::UnlockedFile,
-        runtime::{self, Runtime, Strategy},
-    };
-
     use super::{run_and_destroy, run_and_stop};
+    use crate::prelude::*;
+    use crate::runtime::strategy::{Strategy, StrategyLike};
 
     type TestResult = Result<(), ClusterError>;
 
     fn runtimes() -> Box<dyn Iterator<Item = Runtime>> {
-        let runtimes = runtime::strategy::default().runtimes().collect::<Vec<_>>();
+        let runtimes = Strategy::default().runtimes().collect::<Vec<_>>();
         Box::new(runtimes.into_iter())
     }
 
@@ -165,7 +161,7 @@ mod tests {
             let datadir = tempdir.path().join("data");
             let cluster = Cluster::new(&datadir, runtime)?;
             let lockpath = tempdir.path().join("lock");
-            let lock = UnlockedFile::try_from(&lockpath)?;
+            let lock = lock::UnlockedFile::try_from(&lockpath)?;
             let databases = run_and_stop(&cluster, lock, Cluster::databases)??;
             assert!(!databases.is_empty());
             assert!(!cluster.running()?);
@@ -182,7 +178,7 @@ mod tests {
             let datadir = tempdir.path().join("data");
             let cluster = Cluster::new(&datadir, runtime)?;
             let lockpath = tempdir.path().join("lock");
-            let lock = UnlockedFile::try_from(&lockpath)?;
+            let lock = lock::UnlockedFile::try_from(&lockpath)?;
             let databases = run_and_destroy(&cluster, lock, Cluster::databases)??;
             assert!(!databases.is_empty());
             assert!(!cluster.running()?);

--- a/pgdo-lib/src/prelude.rs
+++ b/pgdo-lib/src/prelude.rs
@@ -8,4 +8,4 @@ pub use crate::{
 };
 
 // Traits.
-pub use crate::runtime::strategy::Strategy;
+pub use crate::runtime::strategy::StrategyLike;

--- a/pgdo-lib/src/runtime.rs
+++ b/pgdo-lib/src/runtime.rs
@@ -7,6 +7,7 @@
 //! finding and selecting runtimes.
 
 mod cache;
+mod constraint;
 mod error;
 pub mod strategy;
 

--- a/pgdo-lib/src/runtime.rs
+++ b/pgdo-lib/src/runtime.rs
@@ -3,8 +3,8 @@
 //! You may have many versions of PostgreSQL installed on a system. For example,
 //! on an Ubuntu system, they may be in `/usr/lib/postgresql/*`. On macOS using
 //! Homebrew, you may find them in `/usr/local/Cellar/postgresql@*`. [`Runtime`]
-//! represents one such runtime; the [`Strategy`] trait represents how to find
-//! and select a runtime.
+//! represents one such runtime; and the [`strategy`] module has tools for
+//! finding and selecting runtimes.
 
 mod cache;
 mod error;
@@ -18,7 +18,6 @@ use std::process::Command;
 use crate::util;
 use crate::version;
 pub use error::RuntimeError;
-pub use strategy::Strategy;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Runtime {
@@ -40,8 +39,8 @@ impl Runtime {
     /// PostgreSQL runtime.
     ///
     /// ```rust
-    /// # use pgdo::runtime::{self, RuntimeError, Strategy};
-    /// # let runtime = runtime::strategy::default().fallback().unwrap();
+    /// # use pgdo::runtime::{RuntimeError, strategy::{Strategy, StrategyLike}};
+    /// # let runtime = Strategy::default().fallback().unwrap();
     /// let version = runtime.execute("pg_ctl").arg("--version").output()?;
     /// # Ok::<(), RuntimeError>(())
     /// ```
@@ -65,8 +64,8 @@ impl Runtime {
     /// [`Self::bindir`].
     ///
     /// ```rust
-    /// # use pgdo::runtime::{self, RuntimeError, Strategy};
-    /// # let runtime = runtime::strategy::default().fallback().unwrap();
+    /// # use pgdo::runtime::{RuntimeError, strategy::{Strategy, StrategyLike}};
+    /// # let runtime = Strategy::default().fallback().unwrap();
     /// let version = runtime.command("bash").arg("-c").arg("echo hello").output();
     /// # Ok::<(), RuntimeError>(())
     /// ```

--- a/pgdo-lib/src/runtime.rs
+++ b/pgdo-lib/src/runtime.rs
@@ -7,7 +7,7 @@
 //! finding and selecting runtimes.
 
 mod cache;
-mod constraint;
+pub mod constraint;
 mod error;
 pub mod strategy;
 

--- a/pgdo-lib/src/runtime/cache.rs
+++ b/pgdo-lib/src/runtime/cache.rs
@@ -92,6 +92,6 @@ fn version_from_binary<P: AsRef<Path>>(binary: P) -> Result<Version, RuntimeErro
         // "pg_ctl (PostgreSQL) 12.2" and get 12.2 out of it.
         Ok(version_string.parse()?)
     } else {
-        Err(VersionError::Missing)?
+        Err(VersionError::NotFound { text: None })?
     }
 }

--- a/pgdo-lib/src/runtime/constraint.rs
+++ b/pgdo-lib/src/runtime/constraint.rs
@@ -98,13 +98,23 @@ impl Constraint {
     }
 
     /// Match **any** of the given constraints.
+    ///
+    /// If there are no constraints, this returns [`Self::Nothing`].
     pub fn any<C: IntoIterator<Item = Constraint>>(constraints: C) -> Self {
-        constraints.into_iter().fold(Self::Nothing, |a, b| a | b)
+        constraints
+            .into_iter()
+            .reduce(|a, b| a | b)
+            .unwrap_or(Self::Nothing)
     }
 
     /// Match **all** of the given constraints.
+    ///
+    /// If there are no constraints, this returns [`Self::Anything`].
     pub fn all<C: IntoIterator<Item = Constraint>>(constraints: C) -> Self {
-        constraints.into_iter().fold(Self::Anything, |a, b| a & b)
+        constraints
+            .into_iter()
+            .reduce(|a, b| a & b)
+            .unwrap_or(Self::Anything)
     }
 
     /// Does the given runtime match this constraint?
@@ -285,6 +295,7 @@ mod test_constraints {
 
     #[test]
     fn test_any() {
+        assert!(matches!(Constraint::any([]), Constraint::Nothing));
         assert!(matches!(
             Constraint::any([
                 Constraint::Anything,
@@ -315,6 +326,7 @@ mod test_constraints {
 
     #[test]
     fn test_all() {
+        assert!(matches!(Constraint::all([]), Constraint::Anything));
         assert!(matches!(
             Constraint::all([
                 Constraint::Anything,

--- a/pgdo-lib/src/runtime/constraint.rs
+++ b/pgdo-lib/src/runtime/constraint.rs
@@ -1,6 +1,6 @@
 use std::{error, fmt, str::FromStr};
 
-use globset::{self, Glob, GlobBuilder, GlobMatcher};
+use globset::{Error as GlobError, Glob, GlobBuilder, GlobMatcher};
 
 use crate::version::{self, PartialVersion, VersionError};
 
@@ -8,7 +8,7 @@ use super::Runtime;
 
 #[derive(Debug)]
 pub enum ConstraintError {
-    GlobError(globset::Error),
+    GlobError(GlobError),
     VersionError(version::VersionError),
 }
 
@@ -35,8 +35,8 @@ impl error::Error for ConstraintError {
     }
 }
 
-impl From<globset::Error> for ConstraintError {
-    fn from(error: globset::Error) -> ConstraintError {
+impl From<GlobError> for ConstraintError {
+    fn from(error: GlobError) -> ConstraintError {
         ConstraintError::GlobError(error)
     }
 }
@@ -77,7 +77,7 @@ impl Constraint {
     /// - empty alternators, e.g. `{,.rs}` are allowed.
     ///
     /// Use [`glob`][`Self::glob`] if you want to select your own rules.
-    pub fn path(pattern: &str) -> Result<Self, globset::Error> {
+    pub fn path(pattern: &str) -> Result<Self, GlobError> {
         Ok(Self::BinDir(
             GlobBuilder::new(pattern)
                 .literal_separator(true)

--- a/pgdo-lib/src/runtime/constraint.rs
+++ b/pgdo-lib/src/runtime/constraint.rs
@@ -1,0 +1,290 @@
+use globset::{self, Glob, GlobBuilder, GlobMatcher};
+
+use crate::version::{PartialVersion, VersionError};
+
+use super::Runtime;
+
+/// A constraint used when selecting a PostgreSQL runtime.
+#[derive(Clone, Debug)]
+pub enum Constraint {
+    /// Match the runtime's `bindir`.
+    BinDir(GlobMatcher),
+    /// Match the given version.
+    Version(PartialVersion),
+    /// Either constraint can be satisfied.
+    Either(Box<Constraint>, Box<Constraint>),
+    /// Both constraints must be satisfied.
+    Both(Box<Constraint>, Box<Constraint>),
+    /// Invert the given constraint; use `!constraint` for the same effect.
+    Not(Box<Constraint>),
+    /// Match any runtime.
+    Anything,
+    /// Match no runtimes at all.
+    Nothing,
+}
+
+impl Constraint {
+    /// Match the given runtime's `bindir` against this glob pattern.
+    ///
+    /// The [syntax](https://docs.rs/globset/latest/globset/index.html#syntax)
+    /// comes from the [globset](https://crates.io/crates/globset) crate.
+    /// However, here we deviate from its default rules:
+    ///
+    /// - `*` and `?` do **not** match path separators (`/`); use `**` for that.
+    /// - empty alternators, e.g. `{,.rs}` are allowed.
+    ///
+    /// Use [`glob`][`Self::glob`] if you want to select your own rules.
+    pub fn path(pattern: &str) -> Result<Self, globset::Error> {
+        Ok(Self::BinDir(
+            GlobBuilder::new(pattern)
+                .literal_separator(true)
+                .empty_alternates(true)
+                .build()?
+                .compile_matcher(),
+        ))
+    }
+
+    /// Match the given runtime's `bindir` against this glob.
+    pub fn glob(glob: &Glob) -> Self {
+        Self::BinDir(glob.compile_matcher())
+    }
+
+    /// Match the given runtime against this version.
+    pub fn version(version: &str) -> Result<Self, VersionError> {
+        Ok(Self::Version(version.parse()?))
+    }
+
+    /// Match **any** of the given constraints.
+    pub fn any<C: IntoIterator<Item = Constraint>>(constraints: C) -> Self {
+        constraints.into_iter().fold(Self::Nothing, |a, b| a | b)
+    }
+
+    /// Match **all** of the given constraints.
+    pub fn all<C: IntoIterator<Item = Constraint>>(constraints: C) -> Self {
+        constraints.into_iter().fold(Self::Anything, |a, b| a & b)
+    }
+
+    /// Does the given runtime match this constraint?
+    pub fn matches(&self, runtime: &Runtime) -> bool {
+        match self {
+            Self::BinDir(matcher) => matcher.is_match(&runtime.bindir),
+            Self::Version(version) => version.compatible(runtime.version),
+            Self::Either(ca, cb) => ca.matches(runtime) || cb.matches(runtime),
+            Self::Both(ca, cb) => ca.matches(runtime) && cb.matches(runtime),
+            Self::Not(constraint) => !constraint.matches(runtime),
+            Self::Anything => true,
+            Self::Nothing => false,
+        }
+    }
+}
+
+impl std::ops::Not for Constraint {
+    type Output = Self;
+
+    /// Invert this constraint.
+    fn not(self) -> Self::Output {
+        match self {
+            Self::Anything => Self::Nothing,
+            Self::Nothing => Self::Anything,
+            Self::Not(constraint) => *constraint,
+            _ => Self::Not(Box::new(self)),
+        }
+    }
+}
+
+impl std::ops::BitOr for Constraint {
+    type Output = Self;
+
+    /// Match either of the constraints.
+    fn bitor(self, rhs: Self) -> Self::Output {
+        match (self, rhs) {
+            (Self::Anything, _) | (_, Self::Anything) => Self::Anything,
+            (Self::Nothing, c) | (c, Self::Nothing) => c,
+            (ca, cb) => Self::Either(Box::new(ca), Box::new(cb)),
+        }
+    }
+}
+
+impl std::ops::BitAnd for Constraint {
+    type Output = Self;
+
+    /// Match both the constraints.
+    fn bitand(self, rhs: Self) -> Self::Output {
+        match (self, rhs) {
+            (Self::Anything, c) | (c, Self::Anything) => c,
+            (Self::Nothing, _) | (_, Self::Nothing) => Self::Nothing,
+            (ca, cb) => Self::Both(Box::new(ca), Box::new(cb)),
+        }
+    }
+}
+
+impl From<PartialVersion> for Constraint {
+    /// Convert a [`PartialVersion`] into a [`Constraint::Version`].
+    fn from(version: PartialVersion) -> Self {
+        Self::Version(version)
+    }
+}
+
+#[cfg(test)]
+mod test_constraints {
+    use super::Constraint;
+    use super::PartialVersion;
+
+    /// An example constraint.
+    const CONSTRAINT: Constraint = Constraint::Version(PartialVersion::Post10m(13));
+
+    #[test]
+    fn test_not() {
+        let c1 = Constraint::Version(PartialVersion::Post10m(13));
+        assert!(matches!(c1, Constraint::Version(_)));
+        let c2 = !c1;
+        assert!(matches!(c2, Constraint::Not(_)));
+        let c3 = !c2;
+        assert!(matches!(c3, Constraint::Version(_)));
+    }
+
+    #[test]
+    fn test_not_anything_and_nothing() {
+        let c1 = Constraint::Anything;
+        let c2 = !c1;
+        assert!(matches!(c2, Constraint::Nothing));
+        let c3 = !c2;
+        assert!(matches!(c3, Constraint::Anything));
+    }
+
+    #[test]
+    fn test_or() {
+        assert!(matches!(
+            Constraint::Anything | CONSTRAINT.clone(),
+            Constraint::Anything
+        ));
+        assert!(matches!(
+            CONSTRAINT.clone() | Constraint::Anything,
+            Constraint::Anything
+        ));
+        assert!(matches!(
+            Constraint::Nothing | CONSTRAINT.clone(),
+            Constraint::Version(_)
+        ));
+        assert!(matches!(
+            CONSTRAINT.clone() | Constraint::Nothing,
+            Constraint::Version(_)
+        ));
+    }
+
+    #[test]
+    fn test_or_anything_and_nothing() {
+        assert!(matches!(
+            Constraint::Anything | Constraint::Anything,
+            Constraint::Anything
+        ));
+        assert!(matches!(
+            Constraint::Nothing | Constraint::Anything,
+            Constraint::Anything
+        ));
+        assert!(matches!(
+            Constraint::Anything | Constraint::Nothing,
+            Constraint::Anything
+        ));
+    }
+
+    #[test]
+    fn test_and() {
+        assert!(matches!(
+            Constraint::Anything & CONSTRAINT.clone(),
+            Constraint::Version(_)
+        ));
+        assert!(matches!(
+            CONSTRAINT.clone() & Constraint::Anything,
+            Constraint::Version(_)
+        ));
+        assert!(matches!(
+            Constraint::Nothing & CONSTRAINT.clone(),
+            Constraint::Nothing
+        ));
+        assert!(matches!(
+            CONSTRAINT.clone() & Constraint::Nothing,
+            Constraint::Nothing
+        ));
+    }
+
+    #[test]
+    fn test_and_anything_and_nothing() {
+        assert!(matches!(
+            Constraint::Anything & Constraint::Anything,
+            Constraint::Anything
+        ));
+        assert!(matches!(
+            Constraint::Nothing & Constraint::Anything,
+            Constraint::Nothing
+        ));
+        assert!(matches!(
+            Constraint::Anything & Constraint::Nothing,
+            Constraint::Nothing
+        ));
+    }
+
+    #[test]
+    fn test_any() {
+        assert!(matches!(
+            Constraint::any([
+                Constraint::Anything,
+                Constraint::Nothing,
+                Constraint::Nothing
+            ]),
+            Constraint::Anything
+        ));
+        assert!(matches!(
+            Constraint::any([Constraint::Nothing, CONSTRAINT.clone(), Constraint::Nothing]),
+            Constraint::Version(_)
+        ));
+        assert!(matches!(
+            Constraint::any([
+                Constraint::Anything,
+                CONSTRAINT.clone(),
+                Constraint::Nothing
+            ]),
+            Constraint::Anything
+        ));
+        assert!(matches!(
+            Constraint::any([CONSTRAINT.clone(), CONSTRAINT.clone()]),
+            Constraint::Either(ca, cb)
+                if matches!(*ca, Constraint::Version(_))
+                && matches!(*cb, Constraint::Version(_))
+        ));
+    }
+
+    #[test]
+    fn test_all() {
+        assert!(matches!(
+            Constraint::all([
+                Constraint::Anything,
+                Constraint::Anything,
+                Constraint::Anything
+            ]),
+            Constraint::Anything
+        ));
+        assert!(matches!(
+            Constraint::all([
+                Constraint::Anything,
+                CONSTRAINT.clone(),
+                Constraint::Anything,
+            ]),
+            Constraint::Version(_),
+        ));
+        assert!(matches!(
+            Constraint::all([
+                Constraint::Anything,
+                CONSTRAINT.clone(),
+                Constraint::Nothing,
+            ]),
+            Constraint::Nothing,
+        ));
+        assert!(matches!(
+            Constraint::all([CONSTRAINT.clone(), CONSTRAINT.clone()]),
+            Constraint::Both(ca, cb)
+                if matches!(*ca, Constraint::Version(_))
+                && matches!(*cb, Constraint::Version(_))
+        ));
+    }
+}

--- a/pgdo-lib/src/runtime/strategy.rs
+++ b/pgdo-lib/src/runtime/strategy.rs
@@ -2,8 +2,7 @@ use std::collections::VecDeque;
 use std::env;
 use std::path::{Path, PathBuf};
 
-pub use super::constraint::Constraint;
-use super::Runtime;
+use super::{constraint::Constraint, Runtime};
 
 pub type Runtimes<'a> = Box<dyn Iterator<Item = Runtime> + 'a>;
 

--- a/pgdo-lib/src/runtime/strategy.rs
+++ b/pgdo-lib/src/runtime/strategy.rs
@@ -1,6 +1,5 @@
 use std::collections::VecDeque;
 use std::env;
-use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 
 use crate::version;
@@ -20,8 +19,9 @@ pub type Runtimes<'a> = Box<dyn Iterator<Item = Runtime> + 'a>;
 /// This trait models those questions, and provides default implementations for
 /// #2 and #3.
 ///
-/// A good place to start is [`default()`]. It might do what you need.
-pub trait Strategy: std::panic::RefUnwindSafe + 'static {
+/// However, a good place to start is the [`Default`] implementation of
+/// [`Strategy`]. It might do what you need.
+pub trait StrategyLike: std::panic::RefUnwindSafe + 'static {
     /// Find all runtimes that this strategy knows about.
     fn runtimes(&self) -> Runtimes;
 
@@ -47,43 +47,41 @@ pub trait Strategy: std::panic::RefUnwindSafe + 'static {
     }
 }
 
-/// Find runtimes on a given path, or on `PATH` (from the environment).
+/// Find runtimes on a given path.
 ///
 /// Parses input according to platform conventions for the `PATH` environment
 /// variable. See [`env::split_paths`] for details.
 #[derive(Clone, Debug)]
-pub enum RuntimesOnPath {
-    /// Find runtimes on the given path.
-    Custom(PathBuf),
-    /// Find runtimes on `PATH` (environment variable).
-    Env,
-}
+pub struct RuntimesOnPath(PathBuf);
 
-impl RuntimesOnPath {
-    fn find_on_path<T: AsRef<OsStr> + ?Sized>(path: &T) -> Vec<PathBuf> {
-        env::split_paths(path)
-            .filter(|bindir| bindir.join("pg_ctl").exists())
-            .collect()
-    }
-
-    fn find_on_env_path() -> Vec<PathBuf> {
-        match env::var_os("PATH") {
-            Some(path) => Self::find_on_path(&path),
-            None => vec![],
-        }
-    }
-}
-
-impl Strategy for RuntimesOnPath {
+impl StrategyLike for RuntimesOnPath {
     fn runtimes(&self) -> Runtimes {
         Box::new(
-            match self {
-                RuntimesOnPath::Custom(path) => Self::find_on_path(path),
-                RuntimesOnPath::Env => Self::find_on_env_path(),
-            }
-            .into_iter()
-            // Throw away runtimes that we can't determine the version for.
-            .filter_map(|bindir| Runtime::new(bindir).ok()),
+            env::split_paths(&self.0)
+                .filter(|bindir| bindir.join("pg_ctl").exists())
+                // Throw away runtimes that we can't determine the version for.
+                .filter_map(|bindir| Runtime::new(bindir).ok()),
+        )
+    }
+}
+
+/// Find runtimes on `PATH` (from the environment).
+#[derive(Clone, Debug)]
+pub struct RuntimesOnPathEnv;
+
+impl StrategyLike for RuntimesOnPathEnv {
+    fn runtimes(&self) -> Runtimes {
+        Box::new(
+            env::var_os("PATH")
+                .map(|path| {
+                    env::split_paths(&path)
+                        .filter(|bindir| bindir.join("pg_ctl").exists())
+                        // Throw away runtimes that we can't determine the version for.
+                        .filter_map(|bindir| Runtime::new(bindir).ok())
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default()
+                .into_iter(),
         )
     }
 }
@@ -154,7 +152,7 @@ impl RuntimesOnPlatform {
     }
 }
 
-impl Strategy for RuntimesOnPlatform {
+impl StrategyLike for RuntimesOnPlatform {
     fn runtimes(&self) -> Runtimes {
         Box::new(
             Self::find()
@@ -165,107 +163,163 @@ impl Strategy for RuntimesOnPlatform {
     }
 }
 
-/// Combine multiple runtime strategies, in order of preference.
-pub struct StrategySet(VecDeque<Box<dyn Strategy>>);
-
-impl StrategySet {
-    pub fn new() -> Self {
-        Self(VecDeque::new())
-    }
-
-    #[must_use]
-    pub fn push_front<S: Strategy>(mut self, strategy: S) -> Self {
-        self.0.push_front(Box::new(strategy));
-        self
-    }
-
-    #[must_use]
-    pub fn push_back<S: Strategy>(mut self, strategy: S) -> Self {
-        self.0.push_back(Box::new(strategy));
-        self
-    }
+/// Compose strategies for finding PostgreSQL runtimes.
+pub enum Strategy {
+    /// Each strategy is consulted in turn.
+    Chain(VecDeque<Strategy>),
+    /// Delegate to another strategy; needed when implementing [`StrategyLike`].
+    Delegated(Box<dyn StrategyLike>),
+    /// A single runtime; it always picks itself.
+    Single(Runtime),
 }
 
-impl Strategy for StrategySet {
-    /// Runtimes known to all strategies, in the same order as each strategy
-    /// returns them.
+impl Strategy {
+    /// Push the given strategy to the front of the chain.
     ///
-    /// Note that runtimes are deduplicated by version number, i.e. if a runtime
-    /// with the same version number appears in multiple strategies, it will
-    /// only be returned the first time it is seen.
-    fn runtimes(&self) -> Runtimes {
-        let mut seen = std::collections::HashSet::new();
-        Box::new(
-            self.0
-                .iter()
-                .flat_map(|strategy| strategy.runtimes())
-                .filter(move |runtime| seen.insert(runtime.version)),
-        )
-    }
-
-    /// Asks each strategy in turn to select a runtime. The first non-[`None`]
-    /// answer is selected.
-    fn select(&self, version: &version::PartialVersion) -> Option<Runtime> {
-        self.0.iter().find_map(|strategy| strategy.select(version))
-    }
-
-    /// Asks each strategy in turn for a fallback runtime. The first
-    /// non-[`None`] answer is selected.
-    fn fallback(&self) -> Option<Runtime> {
-        self.0.iter().find_map(|strategy| strategy.fallback())
-    }
-}
-
-/// Select runtimes from on `PATH` followed by platform-specific runtimes.
-impl Default for StrategySet {
-    fn default() -> Self {
-        let mut strategies: VecDeque<Box<dyn Strategy>> = VecDeque::new();
-        strategies.push_front(Box::new(RuntimesOnPath::Env));
-        strategies.push_back(Box::new(RuntimesOnPlatform));
-        Self(strategies)
-    }
-}
-
-/// Use a single runtime as a strategy.
-impl Strategy for Runtime {
-    /// This runtime itself is the only runtime known to this strategy.
-    fn runtimes(&self) -> Runtimes {
-        Box::new(std::iter::once(self.clone()))
-    }
-
-    /// Return this runtime if the given version constraint is compatible.
-    fn select(&self, version: &version::PartialVersion) -> Option<Runtime> {
-        if version.compatible(self.version) {
-            Some(self.clone())
-        } else {
-            None
+    /// If this isn't already, it is converted into a [`Strategy::Chain`].
+    #[must_use]
+    pub fn push_front<S: Into<Strategy>>(mut self, strategy: S) -> Self {
+        match self {
+            Self::Chain(ref mut chain) => {
+                chain.push_front(strategy.into());
+                self
+            }
+            Self::Delegated(_) | Self::Single(_) => {
+                let mut chain: VecDeque<Strategy> = VecDeque::new();
+                chain.push_front(strategy.into());
+                chain.push_back(self);
+                Self::Chain(chain)
+            }
         }
     }
 
-    /// Always return this runtime.
-    fn fallback(&self) -> Option<Runtime> {
-        Some(self.clone())
+    /// Push the given strategy to the back of the chain.
+    ///
+    /// If this isn't already, it is converted into a [`Strategy::Chain`].
+    #[must_use]
+    pub fn push_back<S: Into<Strategy>>(mut self, strategy: S) -> Self {
+        match self {
+            Self::Chain(ref mut chain) => {
+                chain.push_back(strategy.into());
+                self
+            }
+            Self::Delegated(_) | Self::Single(_) => {
+                let mut chain: VecDeque<Strategy> = VecDeque::new();
+                chain.push_front(self);
+                chain.push_back(strategy.into());
+                Self::Chain(chain)
+            }
+        }
     }
 }
 
-/// The default runtime strategy.
-///
-/// At present this returns the default [`StrategySet`].
-pub fn default() -> impl Strategy {
-    StrategySet::default()
+impl Default for Strategy {
+    /// Select runtimes from on `PATH` followed by platform-specific runtimes.
+    fn default() -> Self {
+        Self::Chain(VecDeque::new())
+            .push_front(RuntimesOnPathEnv)
+            .push_back(RuntimesOnPlatform)
+    }
+}
+
+impl StrategyLike for Strategy {
+    /// - For a [`Strategy::Chain`], yields runtimes known to all strategies, in
+    ///   the same order as each strategy returns them.
+    /// - For a [`Strategy::Delegated`], calls through to the wrapped strategy.
+    /// - For a [`Strategy::Single`], yields the runtime it's holding.
+    ///
+    /// **Note** that for the first two, runtimes are deduplicated by version
+    /// number, i.e. if a runtime with the same version number is yielded by
+    /// multiple strategies, or is yielded multiple times by a single strategy,
+    /// it will only be returned the first time it is seen.
+    fn runtimes(&self) -> Runtimes {
+        match self {
+            Self::Chain(chain) => {
+                let mut seen = std::collections::HashSet::new();
+                Box::new(
+                    chain
+                        .iter()
+                        .flat_map(|strategy| strategy.runtimes())
+                        .filter(move |runtime| seen.insert(runtime.version)),
+                )
+            }
+            Self::Delegated(strategy) => {
+                let mut seen = std::collections::HashSet::new();
+                Box::new(
+                    strategy
+                        .runtimes()
+                        .filter(move |runtime| seen.insert(runtime.version)),
+                )
+            }
+            Self::Single(runtime) => Box::new(std::iter::once(runtime.clone())),
+        }
+    }
+
+    /// - For a [`Strategy::Chain`], asks each strategy in turn to select a
+    ///   runtime. The first non-[`None`] answer is selected.
+    /// - For a [`Strategy::Delegated`], calls through to the wrapped strategy.
+    /// - For a [`Strategy::Single`], returns the runtime if it's compatible.
+    fn select(&self, version: &version::PartialVersion) -> Option<Runtime> {
+        match self {
+            Self::Chain(chain) => chain.iter().find_map(|strategy| strategy.select(version)),
+            Self::Delegated(strategy) => strategy.select(version),
+            Self::Single(runtime) if version.compatible(runtime.version) => Some(runtime.clone()),
+            Self::Single(_) => None,
+        }
+    }
+
+    /// - For a [`Strategy::Chain`], asks each strategy in turn for a fallback
+    ///   runtime. The first non-[`None`] answer is selected.
+    /// - For a [`Strategy::Delegated`], calls through to the wrapped strategy.
+    /// - For a [`Strategy::Single`], returns the runtime it's holding.
+    fn fallback(&self) -> Option<Runtime> {
+        match self {
+            Self::Chain(chain) => chain.iter().find_map(Strategy::fallback),
+            Self::Delegated(strategy) => strategy.fallback(),
+            Self::Single(runtime) => Some(runtime.clone()),
+        }
+    }
+}
+
+impl From<RuntimesOnPath> for Strategy {
+    /// Converts the given strategy into a [`Strategy::Delegated`].
+    fn from(strategy: RuntimesOnPath) -> Self {
+        Self::Delegated(Box::new(strategy))
+    }
+}
+
+impl From<RuntimesOnPathEnv> for Strategy {
+    /// Converts the given strategy into a [`Strategy::Delegated`].
+    fn from(strategy: RuntimesOnPathEnv) -> Self {
+        Self::Delegated(Box::new(strategy))
+    }
+}
+
+impl From<RuntimesOnPlatform> for Strategy {
+    /// Converts the given strategy into a [`Strategy::Delegated`].
+    fn from(strategy: RuntimesOnPlatform) -> Self {
+        Self::Delegated(Box::new(strategy))
+    }
+}
+
+impl From<Runtime> for Strategy {
+    /// Converts the given runtime into a [`Strategy::Single`].
+    fn from(runtime: Runtime) -> Self {
+        Self::Single(runtime)
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use std::env;
 
-    use super::{RuntimesOnPath, RuntimesOnPlatform, Strategy, StrategySet};
+    use super::{RuntimesOnPath, RuntimesOnPathEnv, RuntimesOnPlatform, Strategy, StrategyLike};
 
     /// This will fail if there are no PostgreSQL runtimes installed.
     #[test]
     fn runtime_find_custom_path() {
         let path = env::var_os("PATH").expect("PATH not set");
-        let strategy = RuntimesOnPath::Custom(path.into());
+        let strategy = RuntimesOnPath(path.into());
         let runtimes = strategy.runtimes();
         assert_ne!(0, runtimes.count());
     }
@@ -273,7 +327,7 @@ mod tests {
     /// This will fail if there are no PostgreSQL runtimes installed.
     #[test]
     fn runtime_find_env_path() {
-        let runtimes = RuntimesOnPath::Env.runtimes();
+        let runtimes = RuntimesOnPathEnv.runtimes();
         assert_ne!(0, runtimes.count());
     }
 
@@ -290,7 +344,7 @@ mod tests {
     /// the strategies of which the default [`StrategySet`] is composed.
     #[test]
     fn runtime_strategy_set_default() {
-        let strategy = StrategySet::default();
+        let strategy = Strategy::default();
         // There is at least one runtime available.
         let runtimes = strategy.runtimes();
         assert_ne!(0, runtimes.count());

--- a/pgdo-lib/src/version/error.rs
+++ b/pgdo-lib/src/version/error.rs
@@ -1,17 +1,37 @@
-use std::{error, fmt, num};
+use std::{error, fmt};
 
 /// Error parsing a PostgreSQL version number.
 #[derive(Debug, PartialEq)]
 pub enum VersionError {
-    BadlyFormed,
-    Missing,
+    BadlyFormed { text: Option<String> },
+    NotFound { text: Option<String> },
+}
+
+impl VersionError {
+    pub fn text(&self) -> Option<&str> {
+        match self {
+            Self::BadlyFormed { text: Some(text) } => Some(text.as_str()),
+            Self::NotFound { text: Some(text) } => Some(text.as_str()),
+            _ => None,
+        }
+    }
 }
 
 impl fmt::Display for VersionError {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            VersionError::BadlyFormed => write!(fmt, "badly formed"),
-            VersionError::Missing => write!(fmt, "not found"),
+        match self {
+            VersionError::BadlyFormed { text: Some(text) } => {
+                write!(fmt, "version string {text:?} is badly formed")
+            }
+            VersionError::BadlyFormed { text: None } => {
+                write!(fmt, "version string is badly formed")
+            }
+            VersionError::NotFound { text: Some(text) } => {
+                write!(fmt, "version not found in {text:?}")
+            }
+            VersionError::NotFound { text: None } => {
+                write!(fmt, "version not found")
+            }
         }
     }
 }
@@ -19,11 +39,5 @@ impl fmt::Display for VersionError {
 impl error::Error for VersionError {
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         None
-    }
-}
-
-impl From<num::ParseIntError> for VersionError {
-    fn from(_error: num::ParseIntError) -> VersionError {
-        VersionError::BadlyFormed
     }
 }


### PR DESCRIPTION
Broadens the runtime selection/constraint machinery, and exposes it to the `shell`, `exec`, and `runtimes` commands.

Fixes #7.