### PR TITLE
Work around semaphore issue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,6 +228,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "backoff"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+dependencies = [
+ "getrandom 0.2.16",
+ "instant",
+ "rand 0.8.5",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -985,6 +996,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "io-uring"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1271,6 +1291,7 @@ name = "pgdo-lib"
 version = "0.5.2"
 dependencies = [
  "async-std",
+ "backoff",
  "either",
  "glob",
  "globset",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -454,6 +454,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67773048316103656a637612c4a62477603b777d91d9c62ff2290f9cde178fdb"
+dependencies = [
+ "ctor-proc-macro",
+ "dtor",
+]
+
+[[package]]
+name = "ctor-proc-macro"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2931af7e13dc045d8e9d26afccc6fa115d64e115c9c84b1166288b46f6782c2"
+
+[[package]]
 name = "ctrlc"
 version = "3.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -499,6 +515,21 @@ name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "dtor"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e58a0764cddb55ab28955347b45be00ade43d4d6f3ba4bf3dc354e4ec9432934"
+dependencies = [
+ "dtor-proc-macro",
+]
+
+[[package]]
+name = "dtor-proc-macro"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
 
 [[package]]
 name = "either"
@@ -1267,7 +1298,10 @@ name = "pgdo-test"
 version = "0.5.2"
 dependencies = [
  "async-std",
+ "ctor",
+ "log",
  "pgdo-test-macros",
+ "simple_logger",
  "sqlx",
 ]
 

--- a/pgdo-lib/Cargo.toml
+++ b/pgdo-lib/Cargo.toml
@@ -15,6 +15,7 @@ name = "pgdo"
 path = "src/lib.rs"
 
 [dependencies]
+backoff = "0.4.0"
 either = "1.15.0"
 glob = "0.3.2"
 globset = "0.4.16"

--- a/pgdo-lib/src/cluster.rs
+++ b/pgdo-lib/src/cluster.rs
@@ -324,6 +324,10 @@ impl Cluster {
 
         // Track the logs so that we can see if there's a retryable failure.
         let logfile = self.logfile();
+        let logfile_name = logfile
+            .file_name()
+            .unwrap_or_else(|| "<unknown.log>".as_ref())
+            .display();
         let mut log: logfile::LogFile = logfile.as_path().try_into()?;
 
         // Next, invoke `pg_ctl` to start the cluster.
@@ -345,7 +349,7 @@ impl Cluster {
         // has visibility of it.
         let append_logs_to_stderr = |output: &mut Output| {
             writeln!(&mut output.stderr)?;
-            writeln!(&mut output.stderr, "-- postmaster.log --")?;
+            writeln!(&mut output.stderr, "-- {logfile_name} --")?;
             log.read_to_end(&mut output.stderr)?;
             Ok(())
         };

--- a/pgdo-lib/src/lib.rs
+++ b/pgdo-lib/src/lib.rs
@@ -6,6 +6,7 @@
 #![allow(clippy::missing_errors_doc)]
 #![allow(clippy::module_name_repetitions)]
 #![allow(clippy::must_use_candidate)]
+#![allow(clippy::redundant_else)]
 
 pub mod cluster;
 pub mod coordinate;

--- a/pgdo-lib/src/runtime.rs
+++ b/pgdo-lib/src/runtime.rs
@@ -67,7 +67,7 @@ impl Runtime {
     /// ```rust
     /// # use pgdo::runtime::{RuntimeError, strategy::{Strategy, StrategyLike}};
     /// # let runtime = Strategy::default().fallback().unwrap();
-    /// let version = runtime.command("bash").arg("-c").arg("echo hello").output();
+    /// let hello = runtime.command("bash").arg("-c").arg("echo hello").output()?;
     /// # Ok::<(), RuntimeError>(())
     /// ```
     ///

--- a/pgdo-lib/tests/test_cluster_backup.rs
+++ b/pgdo-lib/tests/test_cluster_backup.rs
@@ -52,7 +52,6 @@ fn cluster_backup() -> TestResult {
             .filter_map(Result::ok)
             .filter(is_file)
             .collect::<Vec<_>>();
-        dbg!(&files_wal);
         assert_ne!(files_wal.len(), 0);
 
         // A base backup is in place alongside the WAL file directory.

--- a/pgdo-test/Cargo.toml
+++ b/pgdo-test/Cargo.toml
@@ -19,7 +19,10 @@ path = "src/lib.rs"
 
 [dependencies]
 async-std = "1.13.1"
+ctor = "0.5.0"
+log = "0.4.27"
 pgdo-test-macros = { path = "../pgdo-test-macros" }
+simple_logger = "5.0.0"
 
 [dependencies.sqlx]
 version = "0.8.6"

--- a/pgdo-test/src/lib.rs
+++ b/pgdo-test/src/lib.rs
@@ -1,2 +1,15 @@
 pub mod sakila;
 pub use pgdo_test_macros::for_all_runtimes;
+
+#[ctor::ctor]
+/// Initialise a logger for tests. Without this, logs are not emitted – and we
+/// are left with less informative captured test output when tests fail.
+unsafe fn init_logger() {
+    use std::io::{stdout, IsTerminal};
+    simple_logger::SimpleLogger::new()
+        .with_level(log::LevelFilter::Warn)
+        .with_colors(stdout().is_terminal())
+        .env()
+        .init()
+        .expect("could not initialize logger");
+}


### PR DESCRIPTION
In all presently released versions of PostgreSQL, `pg_ctl` can fail on some platforms (macOS, some BSDs) due to a semget(2) failure. This is a particular problem in PostgreSQL 17.x (the linked bug report has more information). As an imperfect workaround, `pgdo` retries the command a few times when it detects this specific error.

See the [original bug report to the pgsql-hackers mailing list](https://www.postgresql.org/message-id/CALL7chmzY3eXHA7zHnODUVGZLSvK3wYCSP0RmcDFHJY8f28Q3g@mail.gmail.com).